### PR TITLE
Go1.8 is now available via cloudsdk and legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 Marvin provides common tools and structure for services being built on Google App Engine by leaning heavily on the [go-kit/kit/transport/http package](http://godoc.org/github.com/go-kit/kit/transport/http). The [service interface here](http://godoc.org/github.com/NYTimes/marvin#Service) is very similar to the service interface in [NYT's gizmo/server/kit package](https://godoc.org/github.com/NYTimes/gizmo/server/kit#Service) so teams can build very similar looking software but use vasty different styles of infrastructure.
 
-Marvin has been built to work with the new Go 1.8 (beta) SDK, which is only available via the legacy App Engine SDK.
+Marvin has been built to work with Go 1.8, currently in open beta on App Engine Standard. Use it by setting `api_version: go1.8` in your app.yaml.

--- a/examples/reading-list/README.md
+++ b/examples/reading-list/README.md
@@ -2,11 +2,16 @@
 
 This example implements a clone of NYT's 'saved articles API' that allows users to save, delete and retrieve nytimes.com article URLs.
 
-Instead of utilizing NYT's auth, this example leans on Google OAuth for user identity. When running locally, GAE's dev_appserver.py appears to always inject a user with an ID of "0".
+Instead of utilizing NYT's auth, this example leans on Google OAuth for user identity. When running locally, GAE's `dev_appserver.py` appears to always inject a user with an ID of "0".
 
-To run this service, you must have the 'legacy' App Engine SDK installed at the latest version that supports Go 1.8, then execute the following command in the nested `/api` directory:
+To run this service, you must be using [Google Cloud SDK](https://cloud.google.com/appengine/docs/standard/go/download) >= `162.0.0` or the "original" App Engine Go SDK >= `1.9.56`. Then execute the following command:
 
-`goapp serve`
+```sh
+# If using Cloud SDK:
+dev_appserver.py api/app.yaml
+# If using the original SDK:
+goapp serve api/app.yaml
+```
 
 At that point the application should be served on http://localhost:8080.
 


### PR DESCRIPTION
Also added a brief instruction on how to use the 1.8 beta.