### PR TITLE
example: style changes

### DIFF
--- a/examples/reading-list/api/app.yaml
+++ b/examples/reading-list/api/app.yaml
@@ -1,6 +1,5 @@
 runtime: go
 api_version: go1.8
-module: default
 
 handlers:
 - url: /.*

--- a/examples/reading-list/api/get.go
+++ b/examples/reading-list/api/get.go
@@ -1,4 +1,4 @@
-package api
+package main
 
 import (
 	"context"

--- a/examples/reading-list/api/put.go
+++ b/examples/reading-list/api/put.go
@@ -1,4 +1,4 @@
-package api
+package main
 
 import (
 	"context"

--- a/examples/reading-list/api/service.go
+++ b/examples/reading-list/api/service.go
@@ -1,20 +1,24 @@
-package api
+package main
 
 import (
 	"context"
 	"net/http"
 	"strings"
 
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/user"
+
 	"github.com/NYTimes/marvin"
 	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
-	"google.golang.org/appengine/user"
 
 	readinglist "github.com/NYTimes/marvin/examples/reading-list"
 )
 
-func init() {
+func main() {
 	marvin.Init(newService())
+
+	appengine.Main()
 }
 
 type httpService struct {

--- a/examples/reading-list/api/service_test.go
+++ b/examples/reading-list/api/service_test.go
@@ -1,4 +1,4 @@
-package api
+package main
 
 import (
 	"bytes"

--- a/examples/reading-list/db.go
+++ b/examples/reading-list/db.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"strings"
 
+	"google.golang.org/appengine/datastore"
+
 	"github.com/pkg/errors"
 	ocontext "golang.org/x/net/context"
-	"google.golang.org/appengine/datastore"
 )
 
 type DB interface {

--- a/examples/reading-list/service.go
+++ b/examples/reading-list/service.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/NYTimes/marvin"
-	"github.com/pkg/errors"
 	"google.golang.org/appengine/log"
 	"google.golang.org/appengine/user"
+
+	"github.com/NYTimes/marvin"
+	"github.com/pkg/errors"
 )
 
 type Service interface {


### PR DESCRIPTION
Use appengine.Main() and have the main entrypoint be a main package,
which allows for better portability over using init().

Import grouping: goimports groups imports this way by default.