### PR TITLE
example/cmd/cli: use app default credentials, clean up error handling

### DIFF
--- a/examples/reading-list/cmd/cli/README.md
+++ b/examples/reading-list/cmd/cli/README.md
@@ -1,3 +1,23 @@
 # The Reading List CLI
 
-To generate an oauth token, this CLI tool accepts a `-creds` flag which points to a GCP JSON key file.
+Use `gcloud auth application-default login` to generate credentials.
+
+Alternatively, you can use the `-creds` flag that points to the path of a Google service account JSON key file.
+
+## Usage
+
+```
+Usage of cli:
+  -creds string
+      the path of the service account credentials file. if empty, uses Google Application Default Credentials.
+  -delete
+      delete this URL from the list (requires -mode update)
+  -host string
+      the host of the reading list server (default "http://localhost:8080")
+  -limit int
+      limit for the number of links to return when listing links (default 20)
+  -mode string
+      (list|update) (default "list")
+  -url string
+      the URL to add or delete
+```


### PR DESCRIPTION
Use Google application default credentials by default:
https://developers.google.com/identity/protocols/application-default-credentials

Remove panics to clean up error messages sent to stderr.