### PR TITLE
updating marvintest docs + adding SetServerContext

### DIFF
--- a/examples/reading-list/vendor/github.com/NYTimes/marvin/marvintest/context.go
+++ b/examples/reading-list/vendor/github.com/NYTimes/marvin/marvintest/context.go
@@ -10,12 +10,20 @@ import (
 	"github.com/NYTimes/marvin/internal"
 )
 
-// SetupTestContext is helpful for unit testing `ae` servers.
+// SetupTestContext will start up dev_appserver.py via `appengine/aetest` and inject the
+// context into the marvin server so users can call
+// `marvin.NewServer(svc).ServeHTTP(w, r)` within tests.
+// This call is very expensive and should be used sparingly in your test suite.
 func SetupTestContext(t *testing.T) func() {
 	_, done := SetupTestContextWithContext(t)
 	return done
 }
 
+// SetupTestContextWithContext will start up dev_appserver.py via `appengine/aetest` and
+// inject the context into the marvin server so users can call
+// `marvin.NewServer(svc).ServeHTTP(w, r)` within tests. This function also returns the
+// server context for use outside the server.
+// This call is very expensive and should be used sparingly in your test suite.
 func SetupTestContextWithContext(t *testing.T) (context.Context, func()) {
 	ctx, done, err := aetest.NewContext()
 	if err != nil {
@@ -27,7 +35,10 @@ func SetupTestContextWithContext(t *testing.T) (context.Context, func()) {
 	return ctx, done
 }
 
-// SetupBenchmarkContext is helpful for benchmarking `ae` servers.
+// SetupBenchmarkContext will start up dev_appserver.py via `appengine/aetest` and inject the
+// context into the marvin server so users can call `marvin.NewServer(svc).ServeHTTP(w, r)`
+// within tests.
+// This call is very expensive and should be used sparingly in your test suite.
 func SetupBenchmarkContext(t *testing.B) func() {
 	ctx, done, err := aetest.NewContext()
 	if err != nil {
@@ -37,4 +48,12 @@ func SetupBenchmarkContext(t *testing.B) func() {
 		return ctx
 	}
 	return done
+}
+
+// SetServerContext will override the server context and inject the given context
+// into incoming requests. The effect of this function is global.
+func SetServerContext(ctx context.Context) {
+	internal.NewContext = func(r *http.Request) context.Context {
+		return ctx
+	}
 }

--- a/marvintest/context.go
+++ b/marvintest/context.go
@@ -10,12 +10,20 @@ import (
 	"github.com/NYTimes/marvin/internal"
 )
 
-// SetupTestContext is helpful for unit testing `ae` servers.
+// SetupTestContext will start up dev_appserver.py via `appengine/aetest` and inject the
+// context into the marvin server so users can call
+// `marvin.NewServer(svc).ServeHTTP(w, r)` within tests.
+// This call is very expensive and should be used sparingly in your test suite.
 func SetupTestContext(t *testing.T) func() {
 	_, done := SetupTestContextWithContext(t)
 	return done
 }
 
+// SetupTestContextWithContext will start up dev_appserver.py via `appengine/aetest` and
+// inject the context into the marvin server so users can call
+// `marvin.NewServer(svc).ServeHTTP(w, r)` within tests. This function also returns the
+// server context for use outside the server.
+// This call is very expensive and should be used sparingly in your test suite.
 func SetupTestContextWithContext(t *testing.T) (context.Context, func()) {
 	ctx, done, err := aetest.NewContext()
 	if err != nil {
@@ -27,7 +35,10 @@ func SetupTestContextWithContext(t *testing.T) (context.Context, func()) {
 	return ctx, done
 }
 
-// SetupBenchmarkContext is helpful for benchmarking `ae` servers.
+// SetupBenchmarkContext will start up dev_appserver.py via `appengine/aetest` and inject the
+// context into the marvin server so users can call `marvin.NewServer(svc).ServeHTTP(w, r)`
+// within tests.
+// This call is very expensive and should be used sparingly in your test suite.
 func SetupBenchmarkContext(t *testing.B) func() {
 	ctx, done, err := aetest.NewContext()
 	if err != nil {
@@ -37,4 +48,12 @@ func SetupBenchmarkContext(t *testing.B) func() {
 		return ctx
 	}
 	return done
+}
+
+// SetServerContext will override the server context and inject the given context
+// into incoming requests. The effect of this function is global.
+func SetServerContext(ctx context.Context) {
+	internal.NewContext = func(r *http.Request) context.Context {
+		return ctx
+	}
 }


### PR DESCRIPTION
This adds documentation to the existing `marvintest` functions that recommend users use them sparingly and it also adds a new hook for users: `marvintest.SetServerContext(context.Context)`

Using this new function, users can init the context once and then alter the context as needed between test steps. This allows users to add a namespace for isolating data instead of rebooting the server.

resolves #9 