### PR TITLE
Update Go1.8 AppEngine statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 
 Marvin provides common tools and structure for services being built on Google App Engine by leaning heavily on the [go-kit/kit/transport/http package](http://godoc.org/github.com/go-kit/kit/transport/http). The [service interface here](http://godoc.org/github.com/NYTimes/marvin#Service) is very similar to the service interface in [NYT's gizmo/server/kit package](https://godoc.org/github.com/NYTimes/gizmo/server/kit#Service) so teams can build very similar looking software but use vasty different styles of infrastructure.
 
-Marvin has been built to work with Go 1.8, currently in open beta on App Engine Standard. Use it by setting `api_version: go1.8` in your app.yaml.
+Marvin has been built to work with Go 1.8, which is available on App Engine Standard.
 
 <sub>The Marvin logo is based on the Go mascot designed by Renée French and copyrighted under the Creative Commons Attribution 3.0 license.</sub>


### PR DESCRIPTION
What
===
Remove statements from the README about Go1.8 on AppEngine that state that it is in beta and provides special configuration.

Why
===
Go1.8 is now the default version of Go in AppEngine. It was announced on October 27th, 2017.
https://cloudplatform.googleblog.com/2017/10/announcing-Go-1-8-on-App-Engine-Standard-Environment.html